### PR TITLE
Fix typo in response variable name and OverflowError catch in shows.py

### DIFF
--- a/api.py
+++ b/api.py
@@ -14,7 +14,7 @@ from resources import guests, hosts, locations, panelists, scorekeepers, shows
 from resources.dicts import error_dict, fail_dict, success_dict
 from wwdtm import VERSION as WWDTM_VERSION
 
-API_VERSION = "0.3.2"
+API_VERSION = "0.3.3"
 
 app = Flask(__name__)
 app.url_map.strict_slashes = False

--- a/resources/guests.py
+++ b/resources/guests.py
@@ -22,10 +22,10 @@ def get_guests(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("guests", guests)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve guests from the database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve guests from the database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "guests from the database")
         return jsonify(response), 500
     except:
@@ -44,11 +44,11 @@ def get_guest_by_id(guest_id: int,
 
         return jsonify(success_dict("guest", guest_info)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve guest information from the "
+        response = error_dict("Unable to retrieve guest information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "guest information")
         return jsonify(response), 500
     except:
@@ -67,11 +67,11 @@ def get_guest_details_by_id(guest_id: int,
 
         return jsonify(success_dict("guest", guest_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve guest information from the "
+        response = error_dict("Unable to retrieve guest information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "guest information")
         return jsonify(response), 500
     except:
@@ -88,10 +88,10 @@ def get_guest_details(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("guests", guest_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve guests from the database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve guests from the database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "guests information")
         return jsonify(response), 500
     except:
@@ -110,11 +110,11 @@ def get_guest_by_slug(guest_slug: str,
 
         return jsonify(success_dict("guest", guest_info)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve guest information from the "
+        response = error_dict("Unable to retrieve guest information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "guest information")
         return jsonify(response), 500
     except:
@@ -134,11 +134,11 @@ def get_guest_details_by_slug(guest_slug: str,
 
         return jsonify(success_dict("guest", guest_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve guest information from the "
+        response = error_dict("Unable to retrieve guest information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "guest information")
         return jsonify(response), 500
     except:

--- a/resources/hosts.py
+++ b/resources/hosts.py
@@ -22,10 +22,10 @@ def get_hosts(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("hosts", hosts)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve hosts from the database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve hosts from the database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "hosts from the database")
         return jsonify(response), 500
     except:
@@ -43,11 +43,11 @@ def get_host_by_id(host_id: int, database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("host", host_info)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve host information from the "
+        response = error_dict("Unable to retrieve host information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "host information")
         return jsonify(response), 500
     except:
@@ -67,11 +67,11 @@ def get_host_details_by_id(host_id: int,
 
         return jsonify(success_dict("host", host_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve host information from the "
+        response = error_dict("Unable to retrieve host information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "host information")
         return jsonify(response), 500
     except:
@@ -88,10 +88,10 @@ def get_host_details(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("hosts", host_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve hosts from the database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve hosts from the database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "host information")
         return jsonify(response), 500
     except:
@@ -110,11 +110,11 @@ def get_host_by_slug(host_slug: str,
 
         return jsonify(success_dict("host", host_info)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve host information from the "
+        response = error_dict("Unable to retrieve host information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "host information")
         return jsonify(response), 500
     except:
@@ -134,11 +134,11 @@ def get_host_details_by_slug(host_slug: str,
 
         return jsonify(success_dict("host", host_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve host information from the "
+        response = error_dict("Unable to retrieve host information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "host information")
         return jsonify(response), 500
     except:

--- a/resources/locations.py
+++ b/resources/locations.py
@@ -22,10 +22,10 @@ def get_locations(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("locations", locations)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve locations from the database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve locations from the database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "locations from the database")
         return jsonify(response), 500
     except:
@@ -89,11 +89,11 @@ def get_location_recordings(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("locations", recordings)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve location recording "
+        response = error_dict("Unable to retrieve location recording "
                               "information from the database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "location recording information")
         return jsonify(response), 500
     except:

--- a/resources/panelists.py
+++ b/resources/panelists.py
@@ -23,10 +23,10 @@ def get_panelists(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("panelists", panelists)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve panelists from the database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve panelists from the database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "panelists from database")
         return jsonify(response), 500
     except:
@@ -141,10 +141,10 @@ def get_panelists_details(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("panelists", panelist_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve panelists from the database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve panelists from the database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "panelists from database")
         return jsonify(response), 500
     except:

--- a/resources/scorekeepers.py
+++ b/resources/scorekeepers.py
@@ -23,11 +23,11 @@ def get_scorekeepers(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("scorekeepers", scorekeepers)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve scorekeepers from the "
+        response = error_dict("Unable to retrieve scorekeepers from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "scorekeepers from the database")
         return jsonify(response), 500
     except:
@@ -46,11 +46,11 @@ def get_scorekeeper_by_id(scorekeeper_id: int,
 
         return jsonify(success_dict("scorekeeper", scorekeeper_info)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve scorekeeper information "
+        response = error_dict("Unable to retrieve scorekeeper information "
                               "from the database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "scorekeeper information")
         return jsonify(response), 500
     except:
@@ -71,11 +71,11 @@ def get_scorekeeper_details_by_id(scorekeeper_id: int,
 
         return jsonify(success_dict("scorekeeper", scorekeeper_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve scorekeeper information "
+        response = error_dict("Unable to retrieve scorekeeper information "
                               "from the database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "scorekeeper information")
         return jsonify(response), 500
     except:
@@ -93,11 +93,11 @@ def get_scorekeeper_details(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("scorekeepers", scorekeeper_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve scorekeepers from the "
+        response = error_dict("Unable to retrieve scorekeepers from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "scorekeepers from database")
         return jsonify(response), 500
     except:
@@ -117,11 +117,11 @@ def get_scorekeeper_by_slug(scorekeeper_slug: str,
 
         return jsonify(success_dict("scorekeeper", scorekeeper_info)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve scorekeeper information "
+        response = error_dict("Unable to retrieve scorekeeper information "
                               "from the database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "scorekeeper information")
         return jsonify(response), 500
     except:
@@ -142,11 +142,11 @@ def get_scorekeeper_details_by_slug(scorekeeper_slug: str,
 
         return jsonify(success_dict("scorekeeper", scorekeeper_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve scorekeeper information "
+        response = error_dict("Unable to retrieve scorekeeper information "
                               "from the database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "scorekeeper information")
         return jsonify(response), 500
     except:

--- a/resources/shows.py
+++ b/resources/shows.py
@@ -22,10 +22,10 @@ def get_shows(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("shows", shows)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve shows from the database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve shows from the database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving shows "
+        response = error_dict("Database error occurred while retrieving shows "
                               "from the database")
         return jsonify(response), 500
     except:
@@ -44,11 +44,11 @@ def get_show_by_id(show_id: int, database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("show", show_info)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve show information from the "
+        response = error_dict("Unable to retrieve show information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "show information")
         return jsonify(response), 500
     except:
@@ -67,11 +67,11 @@ def get_show_details_by_id(show_id: int,
 
         return jsonify(success_dict("show", show_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve show information from the "
+        response = error_dict("Unable to retrieve show information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "show information")
         return jsonify(response), 500
     except:
@@ -90,16 +90,16 @@ def get_show_by_year(show_year: int,
             return jsonify(response), 404
 
         return jsonify(success_dict("shows", show_info)), 200
-    except ValueError:
+    except (OverflowError, ValueError):
         message = "Invalid year {:04d}".format(show_year)
         response = fail_dict("shows", message)
         return jsonify(response), 400
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve show information from the "
+        response = error_dict("Unable to retrieve show information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "show information")
         return jsonify(response), 500
     except:
@@ -118,16 +118,16 @@ def get_show_details_by_year(show_year: int,
             return jsonify(response), 404
 
         return jsonify(success_dict("shows", show_details)), 200
-    except ValueError:
+    except (OverflowError, ValueError):
         message = "Invalid year {:04d}".format(show_year)
         response = fail_dict("shows", message)
         return jsonify(response), 400
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve show information from the "
+        response = error_dict("Unable to retrieve show information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "show information")
         return jsonify(response), 500
     except:
@@ -149,16 +149,16 @@ def get_show_by_year_month(show_year: int,
             return jsonify(response), 404
 
         return jsonify(success_dict("shows", show_info)), 200
-    except ValueError:
+    except (OverflowError, ValueError):
         message = "Invalid year-month {:04d}-{:02d}".format(show_year, show_month)
         response = fail_dict("shows", message)
         return jsonify(response), 400
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve show information from the "
+        response = error_dict("Unable to retrieve show information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "show information")
         return jsonify(response), 500
     except:
@@ -180,16 +180,16 @@ def get_show_details_by_year_month(show_year: int,
             return jsonify(response), 404
 
         return jsonify(success_dict("shows", show_details)), 200
-    except ValueError:
+    except (OverflowError, ValueError):
         message = "Invalid year-month {:04d}-{:02d}".format(show_year, show_month)
         response = fail_dict("shows", message)
         return jsonify(response), 400
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve show information from the "
+        response = error_dict("Unable to retrieve show information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "show information")
         return jsonify(response), 500
     except:
@@ -215,18 +215,18 @@ def get_show_by_date(show_year: int,
             return jsonify(response), 404
 
         return jsonify(success_dict("show", show_info)), 200
-    except ValueError:
+    except (OverflowError, ValueError):
         message = "Invalid date {:04d}-{:02d}-{:02d}".format(show_year,
                                                           show_month,
                                                           show_day)
         response = fail_dict("show", message)
         return jsonify(response), 400
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve show information from the "
+        response = error_dict("Unable to retrieve show information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "show information")
         return jsonify(response), 500
     except:
@@ -246,16 +246,16 @@ def get_show_by_date_string(show_date: str,
             return jsonify(response), 404
 
         return jsonify(success_dict("show", show_info)), 200
-    except ValueError:
+    except (OverflowError, ValueError):
         message = "Invalid date {}".format(show_date)
         response = fail_dict("show", message)
         return jsonify(response), 400
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve show information from the "
+        response = error_dict("Unable to retrieve show information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "show information")
         return jsonify(response), 500
     except:
@@ -281,18 +281,18 @@ def get_show_details_by_date(show_year: int,
             return jsonify(response), 404
 
         return jsonify(success_dict("show", show_details)), 200
-    except ValueError:
+    except (OverflowError, ValueError):
         message = "Invalid date {:04d}-{:02d}-{:02d}".format(show_year,
                                                           show_month,
                                                           show_day)
         response = fail_dict("show", message)
         return jsonify(response), 400
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve show information from the "
+        response = error_dict("Unable to retrieve show information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "show information")
         return jsonify(response), 500
     except:
@@ -312,16 +312,16 @@ def get_show_details_by_date_string(show_date: str,
             return jsonify(response), 404
 
         return jsonify(success_dict("show", show_details)), 200
-    except ValueError:
+    except (OverflowError, ValueError):
         message = "Invalid date {}".format(show_date)
         response = fail_dict("show", message)
         return jsonify(response), 400
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve show information from the "
+        response = error_dict("Unable to retrieve show information from the "
                               "database")
-        return jsonify(repsonse), 500
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving "
+        response = error_dict("Database error occurred while retrieving "
                               "show information")
         return jsonify(response), 500
     except:
@@ -339,10 +339,10 @@ def get_show_details(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("show", shows)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve shows from the database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve shows from the database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving shows "
+        response = error_dict("Database error occurred while retrieving shows "
                               "from database")
         return jsonify(response), 500
     except:
@@ -359,10 +359,10 @@ def get_recent_shows(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("shows", show_info)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve shows from database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve shows from database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving shows "
+        response = error_dict("Database error occurred while retrieving shows "
                               "from database")
         return jsonify(response), 500
     except:
@@ -380,10 +380,10 @@ def get_recent_shows_details(database_connection: mysql.connector.connect):
 
         return jsonify(success_dict("shows", show_details)), 200
     except ProgrammingError:
-        repsonse = error_dict("Unable to retrieve shows from database")
-        return jsonify(repsonse), 500
+        response = error_dict("Unable to retrieve shows from database")
+        return jsonify(response), 500
     except DatabaseError:
-        repsonse = error_dict("Database error occurred while retrieving shows "
+        response = error_dict("Database error occurred while retrieving shows "
                               "from database")
         return jsonify(response), 500
     except:


### PR DESCRIPTION
A fair number of response variables instances were named "repsonse" rather than "response", which lead to additional errors that weren't handled properly. Also, added OverflowError with ValueError in shows.py to properly catch potential overflow issues.