### PR TITLE
utf8mb4

### DIFF
--- a/config.dist.json
+++ b/config.dist.json
@@ -6,7 +6,10 @@
             "password": "",
             "database": "",
             "port": 3306,
-            "raise_on_warnings": true
+            "raise_on_warnings": true,
+            "compress": true,
+            "charset": "utf8mb4",
+            "collation": "utf8mb4_unicode_ci"
         }
     },
 
@@ -17,7 +20,10 @@
             "password": "",
             "database": "",
             "port": 3306,
-            "raise_on_warnings": true
+            "raise_on_warnings": true,
+            "compress": true,
+            "charset": "utf8mb4",
+            "collation": "utf8mb4_unicode_ci"
         }
     },
 
@@ -28,7 +34,10 @@
             "password": "",
             "database": "",
             "port": 3306,
-            "raise_on_warnings": true
+            "raise_on_warnings": true,
+            "compress": true,
+            "charset": "utf8mb4",
+            "collation": "utf8mb4_unicode_ci"
         }
     }
 }


### PR DESCRIPTION
Explicitly set `charset` and `collation` in the database connection object to use `utf8mb4` and `utf8_unicode_ci` to match version 4.1 of the Stats database